### PR TITLE
atomic_refcounted_string_ref bug fixes  & improvements

### DIFF
--- a/include/status_code_domain.hpp
+++ b/include/status_code_domain.hpp
@@ -230,7 +230,7 @@ public:
   {
     struct _allocated_msg
     {
-      mutable std::atomic<unsigned> count;
+      mutable std::atomic<unsigned> count{1};
     };
     _allocated_msg *&_msg() noexcept { return reinterpret_cast<_allocated_msg *&>(this->_state[0]); }                  // NOLINT
     const _allocated_msg *_msg() const noexcept { return reinterpret_cast<const _allocated_msg *>(this->_state[0]); }  // NOLINT
@@ -280,7 +280,7 @@ public:
 
   public:
     //! Construct from a C string literal allocated using `malloc()`.
-    explicit atomic_refcounted_string_ref(const char *str, size_type len = static_cast<size_type>(-1), void *state1 = nullptr, void *state2 = nullptr) noexcept : string_ref(str, len, new(std::nothrow) _allocated_msg{1}, state1, state2, _refcounted_string_thunk)
+    explicit atomic_refcounted_string_ref(const char *str, size_type len = static_cast<size_type>(-1), void *state1 = nullptr, void *state2 = nullptr) noexcept : string_ref(str, len, new(std::nothrow) _allocated_msg, state1, state2, _refcounted_string_thunk)
     {
       if(_msg() == nullptr)
       {


### PR DESCRIPTION
This PR includes the following bug fixes and improvements:

- pass in _refcounted_string_thunk to string_ref base class constructor, otherwise it incorrectly uses the default _checking_string_thunk
- use nothrow operator new instead of calloc to allocate shared count, in part to fix mismatch with operator delete and also for compatibility with debug or locking based atomic implementations that require the atomic object to be properly constructed before use
- optimization: use acquire-release fence for shared count, with deferred acquire fence on final release ( see https://www.boost.org/doc/libs/1_67_0/doc/html/atomic/usage_examples.html#boost_atomic.usage_examples.example_reference_counters )
- optimization: implement move operation with actual move semantics in _refcounted_string_thunk