### PR TITLE
Replaced safe_reinterpret_cast & reinterpret_cast with erasure_cast

### DIFF
--- a/include/status_code.hpp
+++ b/include/status_code.hpp
@@ -487,7 +487,7 @@ public:
   //! Implicit copy construction from any other status code if its value type is trivially copyable and it would fit into our storage
   template <class DomainType,  //
             typename std::enable_if<detail::type_erasure_is_safe<value_type, typename DomainType::value_type>::value, bool>::type = true>
-  constexpr status_code(const status_code<DomainType> &v) noexcept : _base(v), _value(detail::erasure_cast<value_type, typename DomainType::value_type>(v.value()))
+  constexpr status_code(const status_code<DomainType> &v) noexcept : _base(v), _value(detail::erasure_cast<value_type>(v.value()))
   {
   }
   //! Implicit construction from any type where an ADL discovered `make_status_code(T, Args ...)` returns a `status_code`.

--- a/include/status_code.hpp
+++ b/include/status_code.hpp
@@ -138,40 +138,40 @@ namespace detail
     static_assert(alignof(ErasedType) <= sizeof(ErasedType), "ErasedType must not be over-aligned");
     ErasedType value;
     char padding[N];
-    constexpr padded_erasure_object(ErasedType const &v) noexcept : value(v), padding{} {}
+    constexpr padded_erasure_object(const ErasedType &v) noexcept : value(v), padding{} {}
   };
 
   template <class To, class From,
             typename std::enable_if<is_erasure_castable<To, From>::value && (sizeof(To) == sizeof(From)), bool>::type = true>
-  constexpr To erasure_cast(From const &from) noexcept
+  constexpr To erasure_cast(const From &from) noexcept
   {
     return detail::bit_cast<To>(from);
   }
 
   template <class To, class From,
             typename std::enable_if<is_erasure_castable<To, From>::value && is_static_castable<To, From>::value && (sizeof(To) < sizeof(From)), bool>::type = true>
-  constexpr To erasure_cast(From const &from) noexcept
+  constexpr To erasure_cast(const From &from) noexcept
   {
     return static_cast<To>(detail::bit_cast<typename erasure_integer<From, To>::type>(from));
   }
 
   template <class To, class From,
             typename std::enable_if<is_erasure_castable<To, From>::value && is_static_castable<To, From>::value && (sizeof(To) > sizeof(From)), bool>::type = true>
-  constexpr To erasure_cast(From const &from) noexcept
+  constexpr To erasure_cast(const From &from) noexcept
   {
     return detail::bit_cast<To>(static_cast<typename erasure_integer<To, From>::type>(from));
   }
 
   template <class To, class From,
             typename std::enable_if<is_erasure_castable<To, From>::value && !is_static_castable<To, From>::value && (sizeof(To) < sizeof(From)), bool>::type = true>
-  constexpr To erasure_cast(From const &from) noexcept
+  constexpr To erasure_cast(const From &from) noexcept
   {
     return detail::bit_cast<padded_erasure_object<To, sizeof(From) - sizeof(To)>>(from).value;
   }
 
   template <class To, class From,
             typename std::enable_if<is_erasure_castable<To, From>::value && !is_static_castable<To, From>::value && (sizeof(To) > sizeof(From)), bool>::type = true>
-  constexpr To erasure_cast(From const &from) noexcept
+  constexpr To erasure_cast(const From &from) noexcept
   {
     return detail::bit_cast<To>(padded_erasure_object<From, sizeof(To) - sizeof(From)>{from});
   }


### PR DESCRIPTION
`erasure_cast` overcomes a bug found in the MSVC++ 2017 compiler (up to and including MSVC++ 15.8 Preview 5) where the compiler wasn't aliasing the type-punned values in the `safe_reinterpret_cast` union under certain circumstances. This resulted in a garbage value being stored into system_codes causing the unit tests to fail. I'm not exactly sure why it was happening, but the new `erasure_cast` code seems to work fine (I tried out both the static_cast and union cast code paths).

`erasure_cast` is also guaranteed to be `constexpr` when the input and output types are either integral types or enum types, which contrasts with `safe_reinterpret_cast` and `reinterpret_cast`, neither of which support usage in compile-time expressions (at least in C++17 and prior). Since the vast majority of status_code's are ints and enums, this covers most use cases. It is written in terms of a partially compliant C++20 `std::bit_cast` function to illustrate how this future library facility can be leveraged by implementors. This paves the way for future changes to `status_code<erased<T>>` to enable it for use in compile-time expressions if desired.