### PR TITLE
Add C++20 `<format>`/fmtlib support

### DIFF
--- a/.github/workflows/unittests_linux.yml
+++ b/.github/workflows/unittests_linux.yml
@@ -37,6 +37,7 @@ jobs:
       run: |
         cd build
         bin/test-result
+        bin/test-cxx20-format
         bin/test-status-code
         bin/test-status-code-noexcept
         bin/test-status-code-not-posix

--- a/.github/workflows/unittests_windows.yml
+++ b/.github/workflows/unittests_windows.yml
@@ -13,6 +13,10 @@ jobs:
   WinVS2019:
     name: Windows VS2019
     runs-on: windows-2019
+    strategy:
+      fail-fast: false
+      matrix:
+        standard: [14, 20]
           
     steps:
     - uses: actions/checkout@v2
@@ -20,10 +24,8 @@ jobs:
     - name: CMake build tests Windows
       shell: bash
       run: |
-       mkdir build
-       cd build
-       cmake ..
-       cmake --build . --config Release
+       cmake -S . -B build -DCMAKE_CXX_STANDARD=${{ matrix.standard }}
+       cmake --build build --config Release
       
     - name: CMake run tests Windows
       shell: bash

--- a/.github/workflows/unittests_windows.yml
+++ b/.github/workflows/unittests_windows.yml
@@ -30,6 +30,7 @@ jobs:
       run: |
         cd build
         bin/Release/test-result
+        bin/Release/test-cxx20-format
         bin/Release/test-status-code
         bin/Release/test-status-code-noexcept
         bin/Release/test-status-code-not-posix

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ foreach(source
     "include/status-code/config.hpp"
     "include/status-code/error.hpp"
     "include/status-code/errored_status_code.hpp"
+    "include/status-code/fmt_support.hpp"
     "include/status-code/generic_code.hpp"
     "include/status-code/getaddrinfo_code.hpp"
     "include/status-code/http_status_code.hpp"
@@ -233,6 +234,13 @@ if(NOT PROJECT_IS_DEPENDENCY)
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
   )
   add_test(NAME test-status-code-p0709a COMMAND $<TARGET_FILE:test-status-code-p0709a>)
+
+  add_executable(test-cxx20-format "test/format.cpp")
+  target_link_libraries(test-cxx20-format PRIVATE status-code)
+  set_target_properties(test-cxx20-format PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+  )
+  add_test(NAME test-cxx20-format COMMAND $<TARGET_FILE:test-cxx20-format>)
   
   if(WIN32)
     add_executable(generate-tables "utils/generate-tables.cpp")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 project(status-code VERSION 1.0 LANGUAGES CXX)
 include(GNUInstallDirs)
 enable_testing()
-if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
-  set(PROJECT_IS_DEPENDENCY OFF)
-else()
-  set(PROJECT_IS_DEPENDENCY ON)
+if (NOT DEFINED PROJECT_IS_DEPENDENCY) # don't override cache variables
+  if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    set(PROJECT_IS_DEPENDENCY OFF)
+  else()
+    set(PROJECT_IS_DEPENDENCY ON)
+  endif()
 endif()
 
 # On MSVC very annoyingly cmake puts /EHsc into the global flags which means you

--- a/include/status-code/fmt_support.hpp
+++ b/include/status-code/fmt_support.hpp
@@ -1,0 +1,85 @@
+/* Proposed SG14 status_code
+(C) 2023 Henrik Steffen Gaßmann
+File Created: Apr 2023
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License in the accompanying file
+Licence.txt or at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file Licence.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef SYSTEM_ERROR2_FMT_SUPPORT_HPP
+#define SYSTEM_ERROR2_FMT_SUPPORT_HPP
+
+#include "status_code_domain.hpp"
+
+SYSTEM_ERROR2_NAMESPACE_BEGIN
+
+namespace detail
+{
+  template <class StringView, template <class> class Formatter> struct string_ref_formatter : private Formatter<StringView>
+  {
+  private:
+    using base = Formatter<StringView>;
+
+  public:
+    template <typename ParseContext> constexpr auto parse(ParseContext &ctx) -> typename ParseContext::iterator { return base::parse(ctx); }
+
+    template <typename FormatContext> auto format(const status_code_domain::string_ref &str, FormatContext &ctx) -> typename FormatContext::iterator
+    {
+      return base::format(StringView(str.data(), str.size()), ctx);
+    }
+  };
+}  // namespace detail
+
+SYSTEM_ERROR2_NAMESPACE_END
+
+#if __cpp_lib_format >= 202106L
+#include <format>
+
+SYSTEM_ERROR2_NAMESPACE_BEGIN
+namespace detail
+{
+  template <typename T> using std_formatter = std::formatter<T, char>;
+}
+SYSTEM_ERROR2_NAMESPACE_END
+
+template <>
+struct std::formatter<SYSTEM_ERROR2_NAMESPACE::status_code_domain::string_ref, char>
+    : SYSTEM_ERROR2_NAMESPACE::detail::string_ref_formatter<std::string_view, SYSTEM_ERROR2_NAMESPACE::detail::std_formatter>
+{
+};
+#endif
+
+#if __has_include(<fmt/core.h>)
+#include <fmt/core.h>
+
+SYSTEM_ERROR2_NAMESPACE_BEGIN
+namespace detail
+{
+  template <typename T> using fmt_formatter = fmt::formatter<T, char>;
+}
+SYSTEM_ERROR2_NAMESPACE_END
+
+template <>
+struct fmt::formatter<SYSTEM_ERROR2_NAMESPACE::status_code_domain::string_ref, char>
+    : SYSTEM_ERROR2_NAMESPACE::detail::string_ref_formatter<fmt::string_view, SYSTEM_ERROR2_NAMESPACE::detail::fmt_formatter>
+{
+};
+#endif
+
+#endif

--- a/test/format.cpp
+++ b/test/format.cpp
@@ -1,0 +1,89 @@
+/* Proposed SG14 status_code testing
+(C) 2015-2020 Niall Douglas <http://www.nedproductions.biz/>
+(C) 2023 Henrik Steffen Gaßmann
+File Created: Apr 2023
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License in the accompanying file
+Licence.txt or at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file Licence.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#include "status-code/fmt_support.hpp"
+#include "status-code/generic_code.hpp"
+
+#if __cpp_lib_format >= 202106L
+
+#include <cstdio>
+#include <string>
+
+/* Most of this test suite was ported over from Boost.Outcome's
+experimental-core-result-status.cpp
+*/
+
+#define BOOST_CHECK(expr)                                                                                                                                      \
+  if(!(expr))                                                                                                                                                  \
+  {                                                                                                                                                            \
+    fprintf(stderr, #expr " failed at line %d\n", __LINE__);                                                                                                   \
+    retcode = 1;                                                                                                                                               \
+  }
+#define BOOST_CHECK_THROW(expr, etype)                                                                                                                         \
+  try                                                                                                                                                          \
+  {                                                                                                                                                            \
+    expr;                                                                                                                                                      \
+    fprintf(stderr, #expr " failed to throw " #etype " at line %d\n", __LINE__);                                                                               \
+    retcode = 1;                                                                                                                                               \
+  }                                                                                                                                                            \
+  catch(etype)                                                                                                                                                 \
+  {                                                                                                                                                            \
+  }                                                                                                                                                            \
+  catch(...)                                                                                                                                                   \
+  {                                                                                                                                                            \
+    fprintf(stderr, #expr " failed to throw " #etype " at line %d\n", __LINE__);                                                                               \
+    retcode = 1;                                                                                                                                               \
+  }
+#define BOOST_CHECK_NO_THROW(expr)                                                                                                                             \
+  try                                                                                                                                                          \
+  {                                                                                                                                                            \
+    expr;                                                                                                                                                      \
+  }                                                                                                                                                            \
+  catch(...)                                                                                                                                                   \
+  {                                                                                                                                                            \
+    fprintf(stderr, #expr " failed due to throw at line %d\n", __LINE__);                                                                                      \
+    retcode = 1;                                                                                                                                               \
+  }
+
+int main()
+{
+  using namespace std::string_view_literals;
+  using namespace SYSTEM_ERROR2_NAMESPACE;
+  int retcode = 0;
+
+  {  // format a string_ref
+    generic_code c{errc::bad_address};
+    BOOST_CHECK(std::format("{}", c.message()) == "Bad address"sv);
+  }
+
+  return retcode;
+}
+
+#else
+int main()
+{
+  return 0;
+}
+#endif


### PR DESCRIPTION
Currently contains some basic scaffolding for #51 and the simplest formatter specialization (`string_ref`).