### PR TITLE
fix: Centralize the friend decls for nested status codes

### DIFF
--- a/include/status-code/boost_error_code.hpp
+++ b/include/status-code/boost_error_code.hpp
@@ -66,7 +66,6 @@ namespace mixins
 class _boost_error_code_domain final : public status_code_domain
 {
   template <class DomainType> friend class status_code;
-  template <class StatusCode, class Allocator> friend class detail::indirecting_domain;
   using _base = status_code_domain;
   using _error_code_type = boost::system::error_code;
   using _error_category_type = boost::system::error_category;

--- a/include/status-code/com_code.hpp
+++ b/include/status-code/com_code.hpp
@@ -55,7 +55,6 @@ using com_error = status_error<_com_code_domain>;
 class _com_code_domain : public status_code_domain
 {
   template <class DomainType> friend class status_code;
-  template <class StatusCode, class Allocator> friend class detail::indirecting_domain;
   using _base = status_code_domain;
 
   //! Construct from a `HRESULT` error code

--- a/include/status-code/generic_code.hpp
+++ b/include/status-code/generic_code.hpp
@@ -293,7 +293,6 @@ namespace detail
 class _generic_code_domain : public status_code_domain
 {
   template <class> friend class status_code;
-  template <class StatusCode, class Allocator> friend class detail::indirecting_domain;
   using _base = status_code_domain;
 
 public:

--- a/include/status-code/getaddrinfo_code.hpp
+++ b/include/status-code/getaddrinfo_code.hpp
@@ -48,7 +48,6 @@ using getaddrinfo_error = status_error<_getaddrinfo_code_domain>;
 class _getaddrinfo_code_domain : public status_code_domain
 {
   template <class DomainType> friend class status_code;
-  template <class StatusCode, class Allocator> friend class detail::indirecting_domain;
   using _base = status_code_domain;
 
 public:

--- a/include/status-code/http_status_code.hpp
+++ b/include/status-code/http_status_code.hpp
@@ -57,7 +57,6 @@ namespace mixins
 class _http_status_code_domain : public status_code_domain
 {
   template <class DomainType> friend class status_code;
-  template <class StatusCode, class Allocator> friend class detail::indirecting_domain;
   using _base = status_code_domain;
 
 public:

--- a/include/status-code/nested_status_code.hpp
+++ b/include/status-code/nested_status_code.hpp
@@ -96,32 +96,32 @@ namespace detail
     {
       assert(code.domain() == *this);
       const auto &c = static_cast<const _mycode &>(code);  // NOLINT
-      return typename StatusCode::domain_type()._do_failure(c.value()->sc);
+      return static_cast<status_code_domain &&>(typename StatusCode::domain_type())._do_failure(c.value()->sc);
     }
     virtual bool _do_equivalent(const status_code<void> &code1, const status_code<void> &code2) const noexcept override  // NOLINT
     {
       assert(code1.domain() == *this);
       const auto &c1 = static_cast<const _mycode &>(code1);  // NOLINT
-      return typename StatusCode::domain_type()._do_equivalent(c1.value()->sc, code2);
+      return static_cast<status_code_domain &&>(typename StatusCode::domain_type())._do_equivalent(c1.value()->sc, code2);
     }
     virtual generic_code _generic_code(const status_code<void> &code) const noexcept override  // NOLINT
     {
       assert(code.domain() == *this);
       const auto &c = static_cast<const _mycode &>(code);  // NOLINT
-      return typename StatusCode::domain_type()._generic_code(c.value()->sc);
+      return static_cast<status_code_domain &&>(typename StatusCode::domain_type())._generic_code(c.value()->sc);
     }
     virtual string_ref _do_message(const status_code<void> &code) const noexcept override  // NOLINT
     {
       assert(code.domain() == *this);
       const auto &c = static_cast<const _mycode &>(code);  // NOLINT
-      return typename StatusCode::domain_type()._do_message(c.value()->sc);
+      return static_cast<status_code_domain &&>(typename StatusCode::domain_type())._do_message(c.value()->sc);
     }
 #if defined(_CPPUNWIND) || defined(__EXCEPTIONS) || defined(STANDARDESE_IS_IN_THE_HOUSE)
     SYSTEM_ERROR2_NORETURN virtual void _do_throw_exception(const status_code<void> &code) const override  // NOLINT
     {
       assert(code.domain() == *this);
       const auto &c = static_cast<const _mycode &>(code);  // NOLINT
-      typename StatusCode::domain_type()._do_throw_exception(c.value()->sc);
+      static_cast<status_code_domain &&>(typename StatusCode::domain_type())._do_throw_exception(c.value()->sc);
       abort();                                             // suppress buggy GCC warning
     }
 #endif

--- a/include/status-code/nt_code.hpp
+++ b/include/status-code/nt_code.hpp
@@ -65,7 +65,6 @@ using nt_error = status_error<_nt_code_domain>;
 class _nt_code_domain : public status_code_domain
 {
   template <class DomainType> friend class status_code;
-  template <class StatusCode, class Allocator> friend class detail::indirecting_domain;
   friend class _com_code_domain;
   using _base = status_code_domain;
   static int _nt_code_to_errno(win32::NTSTATUS c)

--- a/include/status-code/posix_code.hpp
+++ b/include/status-code/posix_code.hpp
@@ -73,7 +73,6 @@ namespace mixins
 class _posix_code_domain : public status_code_domain
 {
   template <class DomainType> friend class status_code;
-  template <class StatusCode, class Allocator> friend class detail::indirecting_domain;
   using _base = status_code_domain;
 
   static _base::string_ref _make_string_ref(int c) noexcept

--- a/include/status-code/quick_status_code_from_enum.hpp
+++ b/include/status-code/quick_status_code_from_enum.hpp
@@ -67,7 +67,6 @@ template <class Enum> struct quick_status_code_from_enum_defaults
 template <class Enum> class _quick_status_code_from_enum_domain : public status_code_domain
 {
   template <class DomainType> friend class status_code;
-  template <class StatusCode, class Allocator> friend class detail::indirecting_domain;
   using _base = status_code_domain;
   using _src = quick_status_code_from_enum<Enum>;
 

--- a/include/status-code/std_error_code.hpp
+++ b/include/status-code/std_error_code.hpp
@@ -61,7 +61,6 @@ namespace mixins
 class _std_error_code_domain final : public status_code_domain
 {
   template <class DomainType> friend class status_code;
-  template <class StatusCode, class Allocator> friend class detail::indirecting_domain;
   using _base = status_code_domain;
   using _error_code_type = std::error_code;
   using _error_category_type = std::error_category;

--- a/include/status-code/win32_code.hpp
+++ b/include/status-code/win32_code.hpp
@@ -87,7 +87,6 @@ namespace mixins
 class _win32_code_domain : public status_code_domain
 {
   template <class DomainType> friend class status_code;
-  template <class StatusCode, class Allocator> friend class detail::indirecting_domain;
   friend class _com_code_domain;
   using _base = status_code_domain;
   static int _win32_code_to_errno(win32::DWORD c)


### PR DESCRIPTION
Rely on the fact that `status_code_domain` declares `indirecting_domain` as `friend` and upcast the domain implementation types in places where we access protected `status_code_domain` member functions. This removes the need for custom code-domains to befriend an implementation detail.